### PR TITLE
Revert "Prevented dereferencing of 'nil' pointer in Close function. You run into this issue when you try to make a connection, but the host does not exist."

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,8 +69,4 @@ func Dial(addr string, tr transport.Transport) (*Client, error) {
 }
 
 // Close client connection
-func (c *Client) Close() { 
-	if c != nil {
-		c.Channel.close(c.event) 
-	}
-}
+func (c *Client) Close() { c.Channel.close(c.event) }


### PR DESCRIPTION
Reverts mtfelian/golang-socketio#12