### PR TITLE
Add the option to pass in a `&tls.config{}`

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,7 +70,5 @@ func Dial(addr string, tr transport.Transport) (*Client, error) {
 
 // Close client connection
 func (c *Client) Close() {
-	if c != nil {
-		c.Channel.close(c.event)
-	}
+	c.Channel.close(c.event)
 }

--- a/client.go
+++ b/client.go
@@ -69,6 +69,4 @@ func Dial(addr string, tr transport.Transport) (*Client, error) {
 }
 
 // Close client connection
-func (c *Client) Close() {
-	c.Channel.close(c.event)
-}
+func (c *Client) Close() { c.Channel.close(c.event) }

--- a/client.go
+++ b/client.go
@@ -69,4 +69,8 @@ func Dial(addr string, tr transport.Transport) (*Client, error) {
 }
 
 // Close client connection
-func (c *Client) Close() { c.Channel.close(c.event) }
+func (c *Client) Close() {
+	if c != nil {
+		c.Channel.close(c.event)
+	}
+}

--- a/transport/websocket.go
+++ b/transport/websocket.go
@@ -23,9 +23,7 @@ const (
 
 // WebsocketTransportParams is a parameters for getting non-default websocket transport
 type WebsocketTransportParams struct {
-	Headers http.Header
-	//To provide custom TLS configurations.
-	//Like an insecure: skipVerify etc
+	Headers         http.Header
 	TLSClientConfig *tls.Config
 }
 
@@ -115,6 +113,7 @@ type WebsocketTransport struct {
 	PingTimeout     time.Duration
 	ReceiveTimeout  time.Duration
 	SendTimeout     time.Duration
+	
 	BufferSize      int
 	Headers         http.Header
 	TLSClientConfig *tls.Config
@@ -122,11 +121,7 @@ type WebsocketTransport struct {
 
 // Connect to the given url
 func (t *WebsocketTransport) Connect(url string) (Connection, error) {
-	//If the TLSClientConfig supplied was nil, it will continue to be so when Dial is called.
-	//The above implies that the default behavior will kick in when nil as promised in websocket.Dialer struct
-	dialer := websocket.Dialer{
-		TLSClientConfig: t.TLSClientConfig,
-	}
+	dialer := websocket.Dialer{TLSClientConfig: t.TLSClientConfig}
 	socket, _, err := dialer.Dial(url, t.Headers)
 	if err != nil {
 		return nil, err

--- a/transport/websocket.go
+++ b/transport/websocket.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"crypto/tls"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -21,7 +22,12 @@ const (
 )
 
 // WebsocketTransportParams is a parameters for getting non-default websocket transport
-type WebsocketTransportParams struct{ Headers http.Header }
+type WebsocketTransportParams struct {
+	Headers http.Header
+	//To provide custom TLS configurations.
+	//Like an insecure: skipVerify etc
+	TLSClientConfig *tls.Config
+}
 
 var (
 	errBinaryMessage     = errors.New("binary messages are not supported")
@@ -105,23 +111,26 @@ func (ws *WebsocketConnection) PingParams() (time.Duration, time.Duration) {
 
 // WebsocketTransport implements websocket transport
 type WebsocketTransport struct {
-	PingInterval   time.Duration
-	PingTimeout    time.Duration
-	ReceiveTimeout time.Duration
-	SendTimeout    time.Duration
-
-	BufferSize int
-	Headers    http.Header
+	PingInterval    time.Duration
+	PingTimeout     time.Duration
+	ReceiveTimeout  time.Duration
+	SendTimeout     time.Duration
+	BufferSize      int
+	Headers         http.Header
+	TLSClientConfig *tls.Config
 }
 
 // Connect to the given url
 func (t *WebsocketTransport) Connect(url string) (Connection, error) {
-	dialer := websocket.Dialer{}
+	//If the TLSClientConfig supplied was nil, it will continue to be so when Dial is called.
+	//The above implies that the default behavior will kick in when nil as promised in websocket.Dialer struct
+	dialer := websocket.Dialer{
+		TLSClientConfig: t.TLSClientConfig,
+	}
 	socket, _, err := dialer.Dial(url, t.Headers)
 	if err != nil {
 		return nil, err
 	}
-
 	return &WebsocketConnection{socket, t}, nil
 }
 
@@ -154,8 +163,7 @@ func DefaultWebsocketTransport() *WebsocketTransport {
 		PingTimeout:    wsDefaultPingTimeout,
 		ReceiveTimeout: wsDefaultReceiveTimeout,
 		SendTimeout:    wsDefaultSendTimeout,
-
-		BufferSize: wsDefaultBufferSize,
+		BufferSize:     wsDefaultBufferSize,
 	}
 }
 
@@ -163,5 +171,6 @@ func DefaultWebsocketTransport() *WebsocketTransport {
 func NewWebsocketTransport(params WebsocketTransportParams) *WebsocketTransport {
 	tr := DefaultWebsocketTransport()
 	tr.Headers = params.Headers
+	tr.TLSClientConfig = params.TLSClientConfig
 	return tr
 }


### PR DESCRIPTION
You can now do things like `InsecureSkipVerify:true`. On the condition, you don't pass one in. the TLSClientConfig will be `nil` and the default behavior should kick in, as promised in `websocket.Dialer{}`