### PR TITLE
Please fix the capitalized user name.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.0.5"
 
 [[constraint]]

--- a/logging/log.go
+++ b/logging/log.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var log *logrus.Logger


### PR DESCRIPTION
When I use vgo, vgo (verison 1.11) complains with the following message

go: github.com/Sirupsen/logrus@1.1.1: parsing go.mod: unexpected module path "github.com/sirupsen/logrus"
go: error loading module requirements

So, please fix them.